### PR TITLE
feat: 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.kestra.plugin</groupId>
     <artifactId>plugin-template-maven</artifactId>
-    <version>0.21.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <properties>
         <jdk.version>21</jdk.version>
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <kestra.version>0.21.0</kestra.version>
+        <kestra.version>[1.0,2.0)</kestra.version>
 
         <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>


### PR DESCRIPTION
- Decorrelate plugin version from Kesrta version: only synchronize major version so new plugins should start at 1.0.0
- Use a minimal Kestra version of 1.0 and maximum o 2.0
