### PR TITLE
fix: replace deprecated Property<> constructor with Property.ofValue/ofExpression

### DIFF
--- a/src/test/java/io/kestra/plugin/templates/ExampleTest.java
+++ b/src/test/java/io/kestra/plugin/templates/ExampleTest.java
@@ -27,7 +27,7 @@ class ExampleTest {
         RunContext runContext = runContextFactory.of(Map.of("variable", "John Doe"));
 
         Example task = Example.builder()
-            .format(new Property<>("Hello {{ variable }}"))
+            .format(Property.ofExpression("Hello {{ variable }}"))
             .build();
 
         Example.Output runOutput = task.run(runContext);


### PR DESCRIPTION
## Summary
- Replace all `new Property<>(...)` constructor calls with the appropriate factory method
- Use `Property.ofExpression(...)` when the argument contains Pebble expressions (`{{...}}`)
- Use `Property.ofValue(...)` for all other cases (literal values, variables, etc.)

The `Property<>` constructor is deprecated in favor of these explicit factory methods.